### PR TITLE
feat: add comprehensive sign-in telemetry

### DIFF
--- a/EastSeat.Agenti.Web/Components/Account/Pages/Login.razor
+++ b/EastSeat.Agenti.Web/Components/Account/Pages/Login.razor
@@ -1,14 +1,17 @@
 ﻿@page "/Account/Login"
 
 @using System.ComponentModel.DataAnnotations
+@using System.Diagnostics
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
 @using EastSeat.Agenti.Web.Data
+@using EastSeat.Agenti.Web.Features.Users
 
 @inject SignInManager<ApplicationUser> SignInManager
 @inject ILogger<Login> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
+@inject ILoginTelemetryService LoginTelemetry
 
 <PageTitle>Log in</PageTitle>
 
@@ -150,17 +153,31 @@
         _isLoggingIn = true;
         errorMessage = null;
 
+        var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var userAgent = HttpContext.Request.Headers.UserAgent.ToString();
+        const string loginMethod = "BlazorWeb";
+
         Logger.LogInformation("LoginUser called - Email: {Email}, RememberMe: {RememberMe}", Input.Email, Input.RememberMe);
-        // This doesn't count login failures towards account lockout
-        // To enable password failures to trigger account lockout, set lockoutOnFailure: true
+
+        var stopwatch = Stopwatch.StartNew();
         var result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure:
         false);
+        stopwatch.Stop();
+        var durationMs = stopwatch.Elapsed.TotalMilliseconds;
 
         Logger.LogInformation("Sign in result - Succeeded: {Succeeded}, RequiresTwoFactor: {RequiresTwoFactor}, IsLockedOut: {IsLockedOut}, IsNotAllowed: {IsNotAllowed}",
         result.Succeeded, result.RequiresTwoFactor, result.IsLockedOut, result.IsNotAllowed);
 
         if (result.Succeeded)
         {
+            var user = await SignInManager.UserManager.FindByEmailAsync(Input.Email);
+            if (user is not null)
+            {
+                await LoginTelemetry.RecordLoginSuccessAsync(
+                    user.Id, Input.Email, loginMethod, ipAddress, userAgent,
+                    user.Role.ToString(), user.BranchId, durationMs);
+            }
+
             Logger.LogInformation("User logged in successfully. Redirecting to: {ReturnUrl}", ReturnUrl ?? "/");
             RedirectManager.RedirectTo(ReturnUrl);
         }
@@ -175,16 +192,25 @@
         }
         else if (result.IsLockedOut)
         {
+            await LoginTelemetry.RecordLoginFailureAsync(
+                Input.Email, "AccountLockedOut", loginMethod, ipAddress, userAgent, durationMs);
+
             Logger.LogWarning("User account locked out.");
             RedirectManager.RedirectTo("Account/Lockout");
         }
         else if (result.IsNotAllowed)
         {
+            await LoginTelemetry.RecordLoginFailureAsync(
+                Input.Email, "AccountNotAllowed", loginMethod, ipAddress, userAgent, durationMs);
+
             Logger.LogWarning("User is not allowed to sign in. Email might not be confirmed.");
             errorMessage = "Error: Your account is not allowed to sign in. Please confirm your email.";
         }
         else
         {
+            await LoginTelemetry.RecordLoginFailureAsync(
+                Input.Email, "InvalidCredentials", loginMethod, ipAddress, userAgent, durationMs);
+
             Logger.LogWarning("Invalid login attempt for email: {Email}", Input.Email);
             errorMessage = "Error: Invalid login attempt.";
         }

--- a/EastSeat.Agenti.Web/Data/UserAuditAction.cs
+++ b/EastSeat.Agenti.Web/Data/UserAuditAction.cs
@@ -7,5 +7,7 @@ public enum UserAuditAction
     Deactivated = 2,
     Reactivated = 3,
     Deleted = 4,
-    PasswordReset = 5
+    PasswordReset = 5,
+    LoginSuccess = 6,
+    LoginFailed = 7
 }

--- a/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
+++ b/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 using EastSeat.Agenti.Web.Data;
+using EastSeat.Agenti.Web.Features.Users;
 
 namespace EastSeat.Agenti.Web.Features.Api;
 
@@ -18,25 +20,52 @@ public static class AuthEndpoints
             LoginRequest request,
             UserManager<ApplicationUser> userManager,
             IConfiguration configuration,
-            ILogger<Program> logger) =>
+            ILogger<Program> logger,
+            ILoginTelemetryService loginTelemetry,
+            HttpContext httpContext) =>
         {
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString();
+            var userAgent = httpContext.Request.Headers.UserAgent.ToString();
+            const string loginMethod = "ApiJwt";
+
             if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
+            {
+                await loginTelemetry.RecordLoginFailureAsync(
+                    request.Email ?? "unknown", "ValidationFailed", loginMethod, ipAddress, userAgent);
                 return Results.BadRequest(ApiResponse<LoginResponse>.Fail("Email and password are required."));
+            }
+
+            var stopwatch = Stopwatch.StartNew();
 
             var user = await userManager.FindByEmailAsync(request.Email);
             if (user is null)
+            {
+                stopwatch.Stop();
+                await loginTelemetry.RecordLoginFailureAsync(
+                    request.Email, "UserNotFound", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
                 return Results.Unauthorized();
+            }
 
             if (!user.IsActive)
             {
-                // Log inactive account attempt for security monitoring
+                stopwatch.Stop();
                 logger.LogWarning("Login attempt for inactive account: {Email}", request.Email);
+                await loginTelemetry.RecordLoginFailureAsync(
+                    request.Email, "InactiveAccount", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
                 return Results.Unauthorized();
             }
 
             var passwordValid = await userManager.CheckPasswordAsync(user, request.Password);
             if (!passwordValid)
+            {
+                stopwatch.Stop();
+                await loginTelemetry.RecordLoginFailureAsync(
+                    request.Email, "InvalidCredentials", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
                 return Results.Unauthorized();
+            }
+
+            stopwatch.Stop();
+            var durationMs = stopwatch.Elapsed.TotalMilliseconds;
 
             var jwtKey = configuration["Jwt:Key"];
             if (string.IsNullOrWhiteSpace(jwtKey))
@@ -48,6 +77,15 @@ public static class AuthEndpoints
             }
 
             var token = GenerateJwtToken(user, configuration);
+
+            await loginTelemetry.RecordLoginSuccessAsync(
+                user.Id, user.Email ?? request.Email, loginMethod, ipAddress, userAgent,
+                user.Role.ToString(), user.BranchId, durationMs);
+
+            loginTelemetry.RecordTokenIssued(
+                user.Id, user.Email ?? request.Email, loginMethod,
+                configuration.GetValue<int>("Jwt:ExpiryMinutes", 60));
+
             var response = new LoginResponse
             {
                 AccessToken = token.Token,

--- a/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
+++ b/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
@@ -28,44 +28,49 @@ public static class AuthEndpoints
             var userAgent = httpContext.Request.Headers.UserAgent.ToString();
             const string loginMethod = "ApiJwt";
 
-            if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
-            {
-                await loginTelemetry.RecordLoginFailureAsync(
-                    request.Email ?? "unknown", "ValidationFailed", loginMethod, ipAddress, userAgent);
-                return Results.BadRequest(ApiResponse<LoginResponse>.Fail("Email and password are required."));
-            }
-
             var stopwatch = Stopwatch.StartNew();
 
-            var user = await userManager.FindByEmailAsync(request.Email);
-            if (user is null)
+            if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
             {
                 stopwatch.Stop();
                 await loginTelemetry.RecordLoginFailureAsync(
-                    request.Email, "UserNotFound", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
+                    request.Email ?? "unknown", "ValidationFailed", loginMethod, ipAddress, userAgent,
+                    stopwatch.Elapsed.TotalMilliseconds);
+                return Results.BadRequest(ApiResponse<LoginResponse>.Fail("Email and password are required."));
+            }
+
+            var user = await userManager.FindByEmailAsync(request.Email);
+
+            // Always verify password to prevent timing-based user enumeration.
+            // When user is null, CheckPasswordAsync is skipped but the overall
+            // response time remains similar due to the telemetry/DB write below.
+            var passwordValid = user is not null &&
+                await userManager.CheckPasswordAsync(user, request.Password);
+
+            stopwatch.Stop();
+            var durationMs = stopwatch.Elapsed.TotalMilliseconds;
+
+            if (user is null)
+            {
+                await loginTelemetry.RecordLoginFailureAsync(
+                    request.Email, "UserNotFound", loginMethod, ipAddress, userAgent, durationMs);
                 return Results.Unauthorized();
             }
 
             if (!user.IsActive)
             {
-                stopwatch.Stop();
                 logger.LogWarning("Login attempt for inactive account: {Email}", request.Email);
                 await loginTelemetry.RecordLoginFailureAsync(
-                    request.Email, "InactiveAccount", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
+                    request.Email, "InactiveAccount", loginMethod, ipAddress, userAgent, durationMs);
                 return Results.Unauthorized();
             }
 
-            var passwordValid = await userManager.CheckPasswordAsync(user, request.Password);
             if (!passwordValid)
             {
-                stopwatch.Stop();
                 await loginTelemetry.RecordLoginFailureAsync(
-                    request.Email, "InvalidCredentials", loginMethod, ipAddress, userAgent, stopwatch.Elapsed.TotalMilliseconds);
+                    request.Email, "InvalidCredentials", loginMethod, ipAddress, userAgent, durationMs);
                 return Results.Unauthorized();
             }
-
-            stopwatch.Stop();
-            var durationMs = stopwatch.Elapsed.TotalMilliseconds;
 
             var jwtKey = configuration["Jwt:Key"];
             if (string.IsNullOrWhiteSpace(jwtKey))

--- a/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
+++ b/EastSeat.Agenti.Web/Features/Api/AuthEndpoints.cs
@@ -41,11 +41,22 @@ public static class AuthEndpoints
 
             var user = await userManager.FindByEmailAsync(request.Email);
 
-            // Always verify password to prevent timing-based user enumeration.
-            // When user is null, CheckPasswordAsync is skipped but the overall
-            // response time remains similar due to the telemetry/DB write below.
-            var passwordValid = user is not null &&
-                await userManager.CheckPasswordAsync(user, request.Password);
+            // Mitigate timing-based user enumeration by performing a dummy password verification
+            // even when the user is not found.
+            bool passwordValid;
+            if (user is not null)
+            {
+                passwordValid = await userManager.CheckPasswordAsync(user, request.Password);
+            }
+            else
+            {
+                // Use a constant dummy hash to consume roughly the same amount of time as a real check.
+                // This value should be any valid Identity password hash; the result is intentionally ignored.
+                const string dummyHash = "AQAAAAEAACcQAAAAEJ1nK1z0zSxN1W/7M7lT9BMG3c0kF4xHCV2+DummyHashForTimingOnly==";
+                var dummyUser = new ApplicationUser();
+                _ = userManager.PasswordHasher.VerifyHashedPassword(dummyUser, dummyHash, request.Password);
+                passwordValid = false;
+            }
 
             stopwatch.Stop();
             var durationMs = stopwatch.Elapsed.TotalMilliseconds;

--- a/EastSeat.Agenti.Web/Features/Users/ILoginTelemetryService.cs
+++ b/EastSeat.Agenti.Web/Features/Users/ILoginTelemetryService.cs
@@ -1,0 +1,8 @@
+namespace EastSeat.Agenti.Web.Features.Users;
+
+public interface ILoginTelemetryService
+{
+    Task RecordLoginSuccessAsync(string userId, string email, string loginMethod, string? ipAddress, string? userAgent, string? role = null, long? branchId = null, double? durationMs = null);
+    Task RecordLoginFailureAsync(string email, string failureReason, string loginMethod, string? ipAddress, string? userAgent, double? durationMs = null);
+    void RecordTokenIssued(string userId, string email, string loginMethod, int expiryMinutes);
+}

--- a/EastSeat.Agenti.Web/Features/Users/LoginTelemetryService.cs
+++ b/EastSeat.Agenti.Web/Features/Users/LoginTelemetryService.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using EastSeat.Agenti.Web.Data;
+using Microsoft.ApplicationInsights;
+using Microsoft.EntityFrameworkCore;
+
+namespace EastSeat.Agenti.Web.Features.Users;
+
+public class LoginTelemetryService(
+    ApplicationDbContext db,
+    ILogger<LoginTelemetryService> logger,
+    TelemetryClient? telemetryClient = null) : ILoginTelemetryService
+{
+    public async Task RecordLoginSuccessAsync(
+        string userId,
+        string email,
+        string loginMethod,
+        string? ipAddress,
+        string? userAgent,
+        string? role = null,
+        long? branchId = null,
+        double? durationMs = null)
+    {
+        db.UserAuditLogs.Add(new UserAuditLog
+        {
+            UserId = userId,
+            Action = UserAuditAction.LoginSuccess,
+            OldValue = SerializeContext(ipAddress, userAgent, loginMethod),
+            NewValue = $"Role={role}, BranchId={branchId}",
+            PerformedByUserId = null,
+            PerformedAt = DateTimeOffset.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+
+        var properties = new Dictionary<string, string>
+        {
+            ["UserId"] = userId,
+            ["Email"] = email,
+            ["LoginMethod"] = loginMethod,
+            ["IpAddress"] = ipAddress ?? "unknown",
+            ["UserAgent"] = Truncate(userAgent, 200),
+            ["Role"] = role ?? "unknown",
+            ["BranchId"] = branchId?.ToString() ?? "none"
+        };
+
+        telemetryClient?.TrackEvent("login_succeeded", properties);
+
+        if (durationMs.HasValue)
+        {
+            telemetryClient?.TrackMetric("login_duration_ms", durationMs.Value);
+        }
+
+        logger.LogInformation(
+            "Login succeeded for {Email} via {LoginMethod} from {IpAddress}",
+            email, loginMethod, ipAddress ?? "unknown");
+    }
+
+    public async Task RecordLoginFailureAsync(
+        string email,
+        string failureReason,
+        string loginMethod,
+        string? ipAddress,
+        string? userAgent,
+        double? durationMs = null)
+    {
+        // For failed logins we may not have a userId, so we store email as the identifier.
+        // Find the user by email to get userId for the audit log, if they exist.
+        var user = await db.Users
+            .Where(u => u.Email == email)
+            .Select(u => new { u.Id })
+            .FirstOrDefaultAsync();
+
+        if (user is not null)
+        {
+            db.UserAuditLogs.Add(new UserAuditLog
+            {
+                UserId = user.Id,
+                Action = UserAuditAction.LoginFailed,
+                OldValue = SerializeContext(ipAddress, userAgent, loginMethod),
+                NewValue = failureReason,
+                PerformedByUserId = null,
+                PerformedAt = DateTimeOffset.UtcNow
+            });
+
+            await db.SaveChangesAsync();
+        }
+
+        var properties = new Dictionary<string, string>
+        {
+            ["Email"] = email,
+            ["FailureReason"] = failureReason,
+            ["LoginMethod"] = loginMethod,
+            ["IpAddress"] = ipAddress ?? "unknown",
+            ["UserAgent"] = Truncate(userAgent, 200)
+        };
+
+        telemetryClient?.TrackEvent("login_failed", properties);
+
+        if (durationMs.HasValue)
+        {
+            telemetryClient?.TrackMetric("login_duration_ms", durationMs.Value);
+        }
+
+        logger.LogWarning(
+            "Login failed for {Email} via {LoginMethod} from {IpAddress}: {FailureReason}",
+            email, loginMethod, ipAddress ?? "unknown", failureReason);
+    }
+
+    public void RecordTokenIssued(string userId, string email, string loginMethod, int expiryMinutes)
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["UserId"] = userId,
+            ["Email"] = email,
+            ["LoginMethod"] = loginMethod,
+            ["ExpiryMinutes"] = expiryMinutes.ToString()
+        };
+
+        telemetryClient?.TrackEvent("jwt_token_issued", properties);
+    }
+
+    private static string SerializeContext(string? ipAddress, string? userAgent, string loginMethod)
+    {
+        var context = new { IpAddress = ipAddress ?? "unknown", UserAgent = Truncate(userAgent, 200), LoginMethod = loginMethod };
+        return JsonSerializer.Serialize(context);
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value)) return "unknown";
+        return value.Length <= maxLength ? value : value[..maxLength];
+    }
+}

--- a/EastSeat.Agenti.Web/Program.cs
+++ b/EastSeat.Agenti.Web/Program.cs
@@ -143,6 +143,7 @@ builder.Services.AddScoped<IAgentService, AgentService>();
 builder.Services.AddScoped<IWalletTypeService, WalletTypeService>();
 builder.Services.AddScoped<IVaultService, VaultService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<ILoginTelemetryService, LoginTelemetryService>();
 builder.Services.AddScoped<ISetupService, SetupService>();
 builder.Services.AddScoped<IThemeService, ThemeService>();
 

--- a/docs/AZURE_LOGS_QUERYING.md
+++ b/docs/AZURE_LOGS_QUERYING.md
@@ -16,6 +16,7 @@ This guide explains how to access, view, and query the logs produced by the Agen
   - [HTTP Requests & API](#http-requests--api)
   - [Exceptions & Errors](#exceptions--errors)
   - [Database (SQL) Performance](#database-sql-performance)
+  - [Authentication & Login](#authentication--login)
   - [User Activity](#user-activity)
 - [Live Metrics Stream](#live-metrics-stream)
 - [Creating a Custom Dashboard](#creating-a-custom-dashboard)
@@ -596,6 +597,133 @@ dependencies
     by name
 | order by AvgDuration desc
 | take 20
+```
+
+---
+
+### Authentication & Login
+
+These are custom events emitted by `LoginTelemetryService` for both Blazor web and API sign-in flows.
+
+#### All login events (success + failure, last 24 hours)
+
+```kql
+customEvents
+| where timestamp > ago(24h)
+| where name in ("login_succeeded", "login_failed")
+| project
+    timestamp,
+    name,
+    Email       = tostring(customDimensions["Email"]),
+    LoginMethod = tostring(customDimensions["LoginMethod"]),
+    IpAddress   = tostring(customDimensions["IpAddress"]),
+    UserAgent   = tostring(customDimensions["UserAgent"])
+| order by timestamp desc
+```
+
+#### Successful logins with user details
+
+```kql
+customEvents
+| where timestamp > ago(7d)
+| where name == "login_succeeded"
+| project
+    timestamp,
+    UserId      = tostring(customDimensions["UserId"]),
+    Email       = tostring(customDimensions["Email"]),
+    Role        = tostring(customDimensions["Role"]),
+    BranchId    = tostring(customDimensions["BranchId"]),
+    LoginMethod = tostring(customDimensions["LoginMethod"]),
+    IpAddress   = tostring(customDimensions["IpAddress"])
+| order by timestamp desc
+```
+
+#### Failed logins by failure reason
+
+```kql
+customEvents
+| where timestamp > ago(7d)
+| where name == "login_failed"
+| summarize Count = count() by
+    FailureReason = tostring(customDimensions["FailureReason"])
+| order by Count desc
+```
+
+#### Failed logins grouped by IP address (brute-force detection)
+
+```kql
+customEvents
+| where timestamp > ago(24h)
+| where name == "login_failed"
+| summarize
+    FailureCount = count(),
+    Emails = make_set(tostring(customDimensions["Email"]))
+    by IpAddress = tostring(customDimensions["IpAddress"])
+| where FailureCount > 5
+| order by FailureCount desc
+```
+
+#### Suspicious: multiple failed logins for the same email in 10 minutes
+
+```kql
+customEvents
+| where timestamp > ago(1d)
+| where name == "login_failed"
+| summarize count() by
+    bin(timestamp, 10m),
+    Email = tostring(customDimensions["Email"])
+| where count_ > 3
+| order by timestamp desc
+```
+
+#### Login latency percentiles (p50, p95, p99)
+
+```kql
+customMetrics
+| where timestamp > ago(24h)
+| where name == "login_duration_ms"
+| summarize
+    P50 = percentile(value, 50),
+    P95 = percentile(value, 95),
+    P99 = percentile(value, 99),
+    Avg = avg(value),
+    Count = count()
+    by bin(timestamp, 1h)
+| order by timestamp desc
+```
+
+#### Logins by method (Blazor Web vs API)
+
+```kql
+customEvents
+| where timestamp > ago(7d)
+| where name in ("login_succeeded", "login_failed")
+| summarize
+    SuccessCount = countif(name == "login_succeeded"),
+    FailureCount = countif(name == "login_failed")
+    by LoginMethod = tostring(customDimensions["LoginMethod"])
+```
+
+#### JWT tokens issued per day
+
+```kql
+customEvents
+| where timestamp > ago(30d)
+| where name == "jwt_token_issued"
+| summarize TokenCount = count() by bin(timestamp, 1d)
+| order by timestamp desc
+```
+
+#### Login activity by branch
+
+```kql
+customEvents
+| where timestamp > ago(7d)
+| where name == "login_succeeded"
+| summarize LoginCount = count() by
+    BranchId = tostring(customDimensions["BranchId"]),
+    LoginMethod = tostring(customDimensions["LoginMethod"])
+| order by LoginCount desc
 ```
 
 ---

--- a/tests/EastSeat.Agenti.UnitTests/Services/LoginTelemetryServiceTests.cs
+++ b/tests/EastSeat.Agenti.UnitTests/Services/LoginTelemetryServiceTests.cs
@@ -1,0 +1,234 @@
+using EastSeat.Agenti.Web.Data;
+using EastSeat.Agenti.Web.Features.Users;
+using FluentAssertions;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace EastSeat.Agenti.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="LoginTelemetryService"/>.
+/// </summary>
+public class LoginTelemetryServiceTests : IDisposable
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly Mock<ILogger<LoginTelemetryService>> _loggerMock;
+    private readonly TelemetryClient _telemetryClient;
+    private readonly LoginTelemetryService _service;
+    private readonly LoginTelemetryService _serviceWithoutTelemetry;
+
+    public LoginTelemetryServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new ApplicationDbContext(options);
+        _loggerMock = new Mock<ILogger<LoginTelemetryService>>();
+
+        var channel = new Mock<ITelemetryChannel>();
+        channel.Setup(c => c.Send(It.IsAny<ITelemetry>()));
+        var config = new TelemetryConfiguration { TelemetryChannel = channel.Object };
+        _telemetryClient = new TelemetryClient(config);
+
+        _service = new LoginTelemetryService(_dbContext, _loggerMock.Object, _telemetryClient);
+        _serviceWithoutTelemetry = new LoginTelemetryService(_dbContext, _loggerMock.Object, null);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    #region RecordLoginSuccessAsync Tests
+
+    [Fact]
+    public async Task RecordLoginSuccessAsync_CreatesAuditLogEntry()
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            Id = "user-1",
+            Email = "test@example.com",
+            FirstName = "Test",
+            LastName = "User",
+            UserName = "test@example.com"
+        };
+        await _dbContext.Users.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await _service.RecordLoginSuccessAsync(
+            "user-1", "test@example.com", "BlazorWeb",
+            "192.168.1.1", "Mozilla/5.0", "Admin", 1, 150.5);
+
+        // Assert
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+        auditLog!.UserId.Should().Be("user-1");
+        auditLog.Action.Should().Be(UserAuditAction.LoginSuccess);
+        auditLog.NewValue.Should().Contain("Admin");
+        auditLog.NewValue.Should().Contain("1");
+    }
+
+    [Fact]
+    public async Task RecordLoginSuccessAsync_IncludesIpAndUserAgentInContext()
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            Id = "user-2",
+            Email = "test2@example.com",
+            FirstName = "Test",
+            LastName = "Two",
+            UserName = "test2@example.com"
+        };
+        await _dbContext.Users.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await _service.RecordLoginSuccessAsync(
+            "user-2", "test2@example.com", "ApiJwt",
+            "10.0.0.1", "AgentiAndroid/1.0", "Agent", 2, null);
+
+        // Assert
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+        auditLog!.OldValue.Should().Contain("10.0.0.1");
+        auditLog.OldValue.Should().Contain("AgentiAndroid/1.0");
+        auditLog.OldValue.Should().Contain("ApiJwt");
+    }
+
+    #endregion
+
+    #region RecordLoginFailureAsync Tests
+
+    [Fact]
+    public async Task RecordLoginFailureAsync_CreatesAuditLogForExistingUser()
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            Id = "user-3",
+            Email = "fail@example.com",
+            FirstName = "Fail",
+            LastName = "User",
+            UserName = "fail@example.com"
+        };
+        await _dbContext.Users.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await _service.RecordLoginFailureAsync(
+            "fail@example.com", "InvalidCredentials", "BlazorWeb",
+            "192.168.1.100", "Mozilla/5.0", 200.0);
+
+        // Assert
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+        auditLog!.UserId.Should().Be("user-3");
+        auditLog.Action.Should().Be(UserAuditAction.LoginFailed);
+        auditLog.NewValue.Should().Be("InvalidCredentials");
+    }
+
+    [Fact]
+    public async Task RecordLoginFailureAsync_DoesNotCreateAuditLogForUnknownUser()
+    {
+        // Act
+        await _service.RecordLoginFailureAsync(
+            "unknown@example.com", "UserNotFound", "ApiJwt",
+            "192.168.1.200", "Mozilla/5.0", 50.0);
+
+        // Assert
+        var auditLogs = await _dbContext.UserAuditLogs.CountAsync();
+        auditLogs.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecordLoginFailureAsync_StoresFailureReasonInNewValue()
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            Id = "user-4",
+            Email = "locked@example.com",
+            FirstName = "Locked",
+            LastName = "User",
+            UserName = "locked@example.com"
+        };
+        await _dbContext.Users.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await _service.RecordLoginFailureAsync(
+            "locked@example.com", "AccountLockedOut", "BlazorWeb",
+            "10.0.0.5", "Chrome/120", null);
+
+        // Assert
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+        auditLog!.NewValue.Should().Be("AccountLockedOut");
+    }
+
+    #endregion
+
+    #region Null TelemetryClient Tests
+
+    [Fact]
+    public async Task RecordLoginSuccessAsync_WithNullTelemetryClient_DoesNotThrow()
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            Id = "user-5",
+            Email = "notelemetry@example.com",
+            FirstName = "No",
+            LastName = "Telemetry",
+            UserName = "notelemetry@example.com"
+        };
+        await _dbContext.Users.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var act = () => _serviceWithoutTelemetry.RecordLoginSuccessAsync(
+            "user-5", "notelemetry@example.com", "BlazorWeb",
+            "127.0.0.1", null, "Agent", null, 100.0);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RecordLoginFailureAsync_WithNullTelemetryClient_DoesNotThrow()
+    {
+        // Act
+        var act = () => _serviceWithoutTelemetry.RecordLoginFailureAsync(
+            "unknown@example.com", "InvalidCredentials", "ApiJwt",
+            null, null, null);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void RecordTokenIssued_WithNullTelemetryClient_DoesNotThrow()
+    {
+        // Act
+        var act = () => _serviceWithoutTelemetry.RecordTokenIssued(
+            "user-1", "test@example.com", "ApiJwt", 60);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Adds comprehensive sign-in telemetry for both Blazor web and API login flows, covering security, operations, and compliance.

## Changes

### New Files
- **\Features/Users/ILoginTelemetryService.cs\** — Interface for centralized sign-in telemetry
- **\Features/Users/LoginTelemetryService.cs\** — Persists \UserAuditLog\ entries, emits Application Insights custom events and metrics
- **\	ests/.../LoginTelemetryServiceTests.cs\** — 8 unit tests

### Modified Files
- **\Data/UserAuditAction.cs\** — Added \LoginSuccess = 6\, \LoginFailed = 7\
- **\Program.cs\** — Registered \ILoginTelemetryService\ as scoped
- **\Components/Account/Pages/Login.razor\** — Instrumented with IP, User-Agent, latency tracking on all sign-in outcomes
- **\Features/Api/AuthEndpoints.cs\** — Full telemetry on all failure/success paths, timing attack prevention
- **\docs/AZURE_LOGS_QUERYING.md\** — Added 'Authentication & Login' section with 9 KQL queries

## Telemetry Events

| Event | Dimensions |
|---|---|
| \login_succeeded\ | UserId, Email, LoginMethod, IpAddress, UserAgent, Role, BranchId |
| \login_failed\ | Email, FailureReason, LoginMethod, IpAddress, UserAgent |
| \jwt_token_issued\ | UserId, Email, LoginMethod, ExpiryMinutes |
| \login_duration_ms\ (metric) | Elapsed milliseconds |

## Security
- Timing attack prevention: password verification runs before user-existence branching to prevent user enumeration
- IP address and User-Agent captured for all login attempts
- Failure reasons tracked: \InvalidCredentials\, \UserNotFound\, \InactiveAccount\, \AccountLockedOut\, \AccountNotAllowed\, \ValidationFailed\

## Testing
- 8 new unit tests — all pass
- Full suite: 226 passed, 0 failed
