### PR TITLE
fix: handle missing Identity role when changing user role

### DIFF
--- a/EastSeat.Agenti.Web/Features/Users/UserService.cs
+++ b/EastSeat.Agenti.Web/Features/Users/UserService.cs
@@ -300,22 +300,28 @@ public class UserService(ApplicationDbContext db, UserManager<ApplicationUser> u
         var oldRoleName = user.Role.ToString();
         var newRoleName = newRole.ToString();
 
-        // Remove from old Identity role
-        var removeResult = await userManager.RemoveFromRoleAsync(user, oldRoleName);
-        if (!removeResult.Succeeded)
+        // Remove from old Identity role (skip if user was never assigned the role in Identity)
+        if (await userManager.IsInRoleAsync(user, oldRoleName))
         {
-            var errors = string.Join(", ", removeResult.Errors.Select(e => e.Description));
-            return new(false, $"Failed to remove old role: {errors}");
+            var removeResult = await userManager.RemoveFromRoleAsync(user, oldRoleName);
+            if (!removeResult.Succeeded)
+            {
+                var errors = string.Join(", ", removeResult.Errors.Select(e => e.Description));
+                return new(false, $"Failed to remove old role: {errors}");
+            }
         }
 
-        // Add to new Identity role
-        var addResult = await userManager.AddToRoleAsync(user, newRoleName);
-        if (!addResult.Succeeded)
+        // Add to new Identity role (skip if already assigned)
+        if (!await userManager.IsInRoleAsync(user, newRoleName))
         {
-            var errors = string.Join(", ", addResult.Errors.Select(e => e.Description));
-            // Try to restore old role
-            await userManager.AddToRoleAsync(user, oldRoleName);
-            return new(false, $"Failed to add new role: {errors}");
+            var addResult = await userManager.AddToRoleAsync(user, newRoleName);
+            if (!addResult.Succeeded)
+            {
+                var errors = string.Join(", ", addResult.Errors.Select(e => e.Description));
+                // Try to restore old role
+                await userManager.AddToRoleAsync(user, oldRoleName);
+                return new(false, $"Failed to add new role: {errors}");
+            }
         }
 
         // Update custom role property

--- a/tests/EastSeat.Agenti.UnitTests/Services/UserServiceTests.cs
+++ b/tests/EastSeat.Agenti.UnitTests/Services/UserServiceTests.cs
@@ -570,6 +570,8 @@ public class UserServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         _userManagerMock.Setup(x => x.FindByIdAsync("admin-2")).ReturnsAsync(admin2);
+        _userManagerMock.Setup(x => x.IsInRoleAsync(admin2, "Admin")).ReturnsAsync(true);
+        _userManagerMock.Setup(x => x.IsInRoleAsync(admin2, "Agent")).ReturnsAsync(false);
         _userManagerMock.Setup(x => x.RemoveFromRoleAsync(admin2, "Admin"))
             .ReturnsAsync(IdentityResult.Success);
         _userManagerMock.Setup(x => x.AddToRoleAsync(admin2, "Agent"))
@@ -588,6 +590,38 @@ public class UserServiceTests : IDisposable
         auditLog!.Action.Should().Be(UserAuditAction.RoleChanged);
         auditLog.OldValue.Should().Be("Admin");
         auditLog.NewValue.Should().Be("Agent");
+    }
+
+    [Fact]
+    public async Task ChangeRoleAsync_WhenUserNotInIdentityRole_SkipsRemoveAndSucceeds()
+    {
+        // Arrange - user has Role=Agent in custom property but no Identity role assigned
+        var admin = UserBuilder.Default().WithId("admin-1").WithRole(UserRole.Admin).Build();
+        var agent = UserBuilder.Default().WithId("agent-1").WithRole(UserRole.Agent).Build();
+        _dbContext.Users.AddRange(admin, agent);
+        await _dbContext.SaveChangesAsync();
+
+        _userManagerMock.Setup(x => x.FindByIdAsync("agent-1")).ReturnsAsync(agent);
+        _userManagerMock.Setup(x => x.IsInRoleAsync(agent, "Agent")).ReturnsAsync(false);
+        _userManagerMock.Setup(x => x.IsInRoleAsync(agent, "Admin")).ReturnsAsync(false);
+        _userManagerMock.Setup(x => x.AddToRoleAsync(agent, "Admin"))
+            .ReturnsAsync(IdentityResult.Success);
+        _userManagerMock.Setup(x => x.UpdateAsync(agent))
+            .ReturnsAsync(IdentityResult.Success);
+
+        // Act
+        var result = await _userService.ChangeRoleAsync("agent-1", UserRole.Admin, "admin-1");
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _userManagerMock.Verify(x => x.RemoveFromRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+        _userManagerMock.Verify(x => x.AddToRoleAsync(agent, "Admin"), Times.Once);
+
+        var auditLog = await _dbContext.UserAuditLogs.FirstOrDefaultAsync();
+        auditLog.Should().NotBeNull();
+        auditLog!.Action.Should().Be(UserAuditAction.RoleChanged);
+        auditLog.OldValue.Should().Be("Agent");
+        auditLog.NewValue.Should().Be("Admin");
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Fixes #32 — "User role cannot be changed to Admin"

- Guard `RemoveFromRoleAsync` and `AddToRoleAsync` with `IsInRoleAsync` checks so role changes succeed even when the `AspNetUserRoles` table is out of sync with the custom `ApplicationUser.Role` property
- Add unit test covering the out-of-sync scenario (user has `Role=Agent` but no Identity role entry)

## Root cause

Investigated the production database for the affected user (doreen.kibuuka@gmail.com, created 2026-02-27). Found that:
- `AspNetUsers.Role` = `1` (numeric, not string — created before enum-as-string conversion was added)
- **`AspNetUserRoles` table has zero entries** for this user — the Identity role was never assigned

When `ChangeRoleAsync` called `RemoveFromRoleAsync(user, "Agent")`, Identity correctly reported the user wasn't in that role, and the code treated it as a hard failure.

## Test plan

- [x] All 220 unit tests pass (0 failures)
- [x] New test `ChangeRoleAsync_WhenUserNotInIdentityRole_SkipsRemoveAndSucceeds` verifies the fix
- [ ] Manual test: change doreen.kibuuka's role from Agent to Admin in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)