### PR TITLE
feat: redesign dashboard with agent wallet summary and vault comparison

### DIFF
--- a/EastSeat.Agenti.Web/Components/Pages/Home.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/Home.razor
@@ -46,46 +46,9 @@
     }
     else
     {
-        <!-- Wallet Balance Cards -->
+        <!-- Session Status -->
         <MudGrid>
-            @foreach (var wallet in _dashboard.Wallets)
-            {
-                <MudItem xs="12" sm="6" md="4">
-                    <MudCard Elevation="2" Class="wallet-card">
-                        <MudCardContent>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Start">
-                                <MudText Typo="Typo.h6">@wallet.WalletTypeIcon @wallet.WalletTypeName</MudText>
-                                @if (wallet.SupportsDenominations)
-                                {
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
-                                        Denominations</MudChip>
-                                }
-                            </MudStack>
-                            <MudText Typo="Typo.body2" Color="Color.Dark" Class="mt-1">@wallet.WalletName</MudText>
-                            <MudText Typo="Typo.h5" Color="Color.Primary" Class="mt-3">
-                                @wallet.Currency @wallet.Balance.ToString("N0")
-                            </MudText>
-                        </MudCardContent>
-                    </MudCard>
-                </MudItem>
-            }
-        </MudGrid>
-
-        <!-- Total Balance Summary -->
-        <MudGrid Class="mt-4">
-            <MudItem xs="12" md="6">
-                <MudCard Elevation="3" Class="total-balance-card">
-                    <MudCardContent>
-                        <MudText Typo="Typo.h6">💰 Total Balance</MudText>
-                        <MudText Typo="Typo.h4" Color="Color.Primary" Class="mt-2">
-                            @_dashboard.Currency @_dashboard.TotalBalance.ToString("N0")
-                        </MudText>
-                    </MudCardContent>
-                </MudCard>
-            </MudItem>
-
-            <!-- Session Status -->
-            <MudItem xs="12" md="6">
+            <MudItem xs="12">
                 <MudCard Elevation="3" Class="session-status-card">
                     <MudCardContent>
                         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -106,6 +69,70 @@
                                 No active session for today. Start a cash count to open a session.
                             </MudText>
                         }
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        </MudGrid>
+
+        <!-- Agent Wallet Summary Table -->
+        <MudGrid Class="mt-4">
+            <MudItem xs="12">
+                <MudCard Elevation="2">
+                    <MudCardContent>
+                        <MudText Typo="Typo.h6" Class="mb-3">Agent Wallet Balances</MudText>
+                        <MudTable Items="@_dashboard.AgentSummaries" Hover="true" Dense="true" Striped="true"
+                            Breakpoint="Breakpoint.Sm">
+                            <HeaderContent>
+                                <MudTh>Agent Name</MudTh>
+                                <MudTh Style="text-align: right">Total Balance</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Agent Name">@context.AgentName</MudTd>
+                                <MudTd DataLabel="Total Balance" Style="text-align: right">
+                                    @context.Currency @context.TotalBalance.ToString("N0")
+                                </MudTd>
+                            </RowTemplate>
+                            <FooterContent>
+                                <MudTd><strong>Total (All Agents)</strong></MudTd>
+                                <MudTd Style="text-align: right">
+                                    <strong>@_dashboard.Currency @_dashboard.TotalAgentBalance.ToString("N0")</strong>
+                                </MudTd>
+                            </FooterContent>
+                        </MudTable>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        </MudGrid>
+
+        <!-- Vault vs Agents Summary -->
+        <MudGrid Class="mt-4">
+            <MudItem xs="12" sm="4">
+                <MudCard Elevation="3">
+                    <MudCardContent>
+                        <MudText Typo="Typo.body2" Color="Color.Default">Vault Balance</MudText>
+                        <MudText Typo="Typo.h5" Color="Color.Primary" Class="mt-1">
+                            @_dashboard.Currency @_dashboard.VaultBalance.ToString("N0")
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudCard Elevation="3">
+                    <MudCardContent>
+                        <MudText Typo="Typo.body2" Color="Color.Default">Total Agent Wallets</MudText>
+                        <MudText Typo="Typo.h5" Color="Color.Primary" Class="mt-1">
+                            @_dashboard.Currency @_dashboard.TotalAgentBalance.ToString("N0")
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudCard Elevation="3" Style="@GetDifferenceCardStyle()">
+                    <MudCardContent>
+                        <MudText Typo="Typo.body2" Style="@GetDifferenceTextStyle()">Difference (Vault - Agents)</MudText>
+                        <MudText Typo="Typo.h5" Style="@GetDifferenceTextStyle()" Class="mt-1">
+                            @_dashboard.Currency @_dashboard.VaultAgentDifference.ToString("N0")
+                        </MudText>
                     </MudCardContent>
                 </MudCard>
             </MudItem>
@@ -150,4 +177,21 @@
         EastSeat.Agenti.Shared.Domain.Enums.CashSessionStatus.Completed => Color.Info,
         _ => Color.Info
     };
+
+    private string GetDifferenceCardStyle()
+    {
+        if (_dashboard is null) return string.Empty;
+        return _dashboard.VaultAgentDifference switch
+        {
+            < 0 => "background-color: #f44336;",
+            > 0 => "background-color: #4caf50;",
+            _ => string.Empty
+        };
+    }
+
+    private string GetDifferenceTextStyle()
+    {
+        if (_dashboard is null) return string.Empty;
+        return _dashboard.VaultAgentDifference != 0 ? "color: white;" : string.Empty;
+    }
 }

--- a/EastSeat.Agenti.Web/Features/Dashboard/AgentWalletSummaryDto.cs
+++ b/EastSeat.Agenti.Web/Features/Dashboard/AgentWalletSummaryDto.cs
@@ -1,0 +1,13 @@
+namespace EastSeat.Agenti.Web.Features.Dashboard;
+
+/// <summary>
+/// Represents an agent's total wallet balance for the dashboard summary table.
+/// </summary>
+public record AgentWalletSummaryDto
+{
+    public long AgentId { get; init; }
+    public string AgentCode { get; init; } = string.Empty;
+    public string AgentName { get; init; } = string.Empty;
+    public decimal TotalBalance { get; init; }
+    public string Currency { get; init; } = "UGX";
+}

--- a/EastSeat.Agenti.Web/Features/Dashboard/DashboardService.cs
+++ b/EastSeat.Agenti.Web/Features/Dashboard/DashboardService.cs
@@ -19,9 +19,6 @@ public class DashboardService : IDashboardService
     /// <inheritdoc />
     public async Task<DashboardViewModel> GetDashboardAsync(string userId)
     {
-        // For now, we'll get wallets that don't have an agent assigned (system wallets)
-        // or wallets where the AgentId matches. In the future, you may want to link
-        // ApplicationUser to an Agent entity.
         var wallets = await _context.Wallets
             .Include(w => w.WalletType)
             .Where(w => w.IsActive)
@@ -38,6 +35,28 @@ public class DashboardService : IDashboardService
                 SupportsDenominations = w.WalletType.SupportsDenominations
             })
             .ToListAsync();
+
+        // Get agent wallet summaries (each agent's total wallet balance)
+        var agentSummaries = await _context.Agents
+            .Where(a => a.IsActive)
+            .Include(a => a.User)
+            .Include(a => a.Wallets.Where(w => w.IsActive))
+            .OrderBy(a => a.User!.FirstName)
+            .ThenBy(a => a.User!.LastName)
+            .Select(a => new AgentWalletSummaryDto
+            {
+                AgentId = a.Id,
+                AgentCode = a.Code,
+                AgentName = a.User != null ? (a.User.FirstName + " " + a.User.LastName).Trim() : a.Code,
+                TotalBalance = a.Wallets.Where(w => w.IsActive).Sum(w => w.Balance),
+                Currency = a.Wallets.Where(w => w.IsActive).Select(w => w.Currency).FirstOrDefault() ?? "UGX"
+            })
+            .ToListAsync();
+
+        // Get vault balance for the branch
+        var vaultBalance = await _context.Vaults
+            .Select(v => v.CurrentBalance)
+            .FirstOrDefaultAsync();
 
         // Get the current session for today
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
@@ -63,7 +82,9 @@ public class DashboardService : IDashboardService
         return new DashboardViewModel
         {
             Wallets = wallets,
+            AgentSummaries = agentSummaries,
             SessionStatus = sessionStatus,
+            VaultBalance = vaultBalance,
             Currency = wallets.FirstOrDefault()?.Currency ?? "UGX"
         };
     }

--- a/EastSeat.Agenti.Web/Features/Dashboard/DashboardViewModel.cs
+++ b/EastSeat.Agenti.Web/Features/Dashboard/DashboardViewModel.cs
@@ -6,8 +6,13 @@ namespace EastSeat.Agenti.Web.Features.Dashboard;
 public record DashboardViewModel
 {
     public IReadOnlyList<WalletBalanceSummaryDto> Wallets { get; init; } = [];
+    public IReadOnlyList<AgentWalletSummaryDto> AgentSummaries { get; init; } = [];
     public SessionStatusDto SessionStatus { get; init; } = new();
     public decimal TotalBalance => Wallets.Sum(w => w.Balance);
+    public decimal TotalAgentBalance => AgentSummaries.Sum(a => a.TotalBalance);
+    public decimal VaultBalance { get; init; }
+    public decimal VaultAgentDifference => VaultBalance - TotalAgentBalance;
     public string Currency { get; init; } = "UGX";
     public bool HasWallets => Wallets.Count > 0;
+    public bool HasAgents => AgentSummaries.Count > 0;
 }


### PR DESCRIPTION
## Summary
- Replace individual wallet balance cards with a table showing each agent's name and total wallet balance
- Add three summary cards below the table: Vault Balance, Total Agent Wallets, and Difference (Vault - Agents)
- Color-code the difference card: green background for positive (vault surplus), red background for negative (agents exceed vault), both with white text

## Test plan
- [x] Verified build succeeds with zero errors
- [x] All 13 existing dashboard unit tests pass
- [x] Tested in browser with positive difference (green card)
- [x] Tested in browser with negative difference (red card)
- [x] Tested with zero balances (neutral card)
- [ ] Verify table displays correctly with multiple agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)