### PR TITLE
feat: redesign cash count UI with tabular layout

### DIFF
--- a/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
@@ -162,40 +162,70 @@
                     @if (context.SupportsDenominations && _expandedWalletIds.Contains(context.WalletId) && context.Denominations != null)
                     {
                         <MudTr>
-                            <td colspan="100" class="pa-4" style="background: var(--mud-palette-background-grey);">
-                                <MudText Typo="Typo.subtitle2" Class="mb-2">Notes</MudText>
-                                <MudStack Row="true" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
-                                    @foreach (var denom in UgxDenominations.Notes)
-                                    {
-                                        var denomKey = denom.ToString();
-                                        <MudNumericField T="int"
-                                            Label="@($"{denom:N0}")"
-                                            Value="@context.Denominations.Notes[denomKey]"
-                                            ValueChanged="@((int v) => OnDenominationChanged(context, denomKey, v, true))"
-                                            Min="0" Variant="Variant.Outlined" Margin="Margin.Dense"
-                                            Style="max-width: 100px;" HideSpinButtons="true" />
-                                    }
-                                </MudStack>
-
-                                <MudText Typo="Typo.subtitle2" Class="mb-2">Coins</MudText>
-                                <MudStack Row="true" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
-                                    @foreach (var denom in UgxDenominations.Coins)
-                                    {
-                                        var denomKey = denom.ToString();
-                                        <MudNumericField T="int"
-                                            Label="@($"{denom:N0}")"
-                                            Value="@context.Denominations.Coins[denomKey]"
-                                            ValueChanged="@((int v) => OnDenominationChanged(context, denomKey, v, false))"
-                                            Min="0" Variant="Variant.Outlined" Margin="Margin.Dense"
-                                            Style="max-width: 100px;" HideSpinButtons="true" />
-                                    }
-                                </MudStack>
-
-                                <MudStack Row="true" Spacing="4" AlignItems="AlignItems.Center">
-                                    <MudText Typo="Typo.caption">Notes: UGX @context.Denominations.NotesTotal.ToString("N0")</MudText>
-                                    <MudText Typo="Typo.caption">Coins: UGX @context.Denominations.CoinsTotal.ToString("N0")</MudText>
-                                    <MudText Typo="Typo.body2"><strong>Total: UGX @context.Denominations.Total.ToString("N0")</strong></MudText>
-                                </MudStack>
+                            <td colspan="100" class="pa-2" style="background: var(--mud-palette-background-grey);">
+                                <MudSimpleTable Dense="true" Hover="true" Style="background: transparent;">
+                                    <thead>
+                                        <tr>
+                                            <th>Denomination</th>
+                                            <th Style="text-align: right; width: 100px;">Qty</th>
+                                            <th Style="text-align: right;">Subtotal (UGX)</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td colspan="3"><strong>Notes</strong></td>
+                                        </tr>
+                                        @foreach (var denom in UgxDenominations.Notes)
+                                        {
+                                            var denomKey = denom.ToString();
+                                            var qty = context.Denominations.Notes[denomKey];
+                                            <tr>
+                                                <td>UGX @denom.ToString("N0")</td>
+                                                <td Style="text-align: right;">
+                                                    <MudNumericField T="int"
+                                                        Value="@qty"
+                                                        ValueChanged="@((int v) => OnDenominationChanged(context, denomKey, v, true))"
+                                                        Min="0" Variant="Variant.Outlined" Margin="Margin.Dense"
+                                                        Style="max-width: 80px;" HideSpinButtons="true" />
+                                                </td>
+                                                <td Style="text-align: right;">@((qty * denom).ToString("N0"))</td>
+                                            </tr>
+                                        }
+                                        <tr style="font-weight: 600;">
+                                            <td colspan="2">Notes Subtotal</td>
+                                            <td Style="text-align: right;">@context.Denominations.NotesTotal.ToString("N0")</td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="3"><strong>Coins</strong></td>
+                                        </tr>
+                                        @foreach (var denom in UgxDenominations.Coins)
+                                        {
+                                            var denomKey = denom.ToString();
+                                            var qty = context.Denominations.Coins[denomKey];
+                                            <tr>
+                                                <td>UGX @denom.ToString("N0")</td>
+                                                <td Style="text-align: right;">
+                                                    <MudNumericField T="int"
+                                                        Value="@qty"
+                                                        ValueChanged="@((int v) => OnDenominationChanged(context, denomKey, v, false))"
+                                                        Min="0" Variant="Variant.Outlined" Margin="Margin.Dense"
+                                                        Style="max-width: 80px;" HideSpinButtons="true" />
+                                                </td>
+                                                <td Style="text-align: right;">@((qty * denom).ToString("N0"))</td>
+                                            </tr>
+                                        }
+                                        <tr style="font-weight: 600;">
+                                            <td colspan="2">Coins Subtotal</td>
+                                            <td Style="text-align: right;">@context.Denominations.CoinsTotal.ToString("N0")</td>
+                                        </tr>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr style="font-weight: 700;">
+                                            <td colspan="2">Total</td>
+                                            <td Style="text-align: right;">UGX @context.Denominations.Total.ToString("N0")</td>
+                                        </tr>
+                                    </tfoot>
+                                </MudSimpleTable>
                             </td>
                         </MudTr>
                     }


### PR DESCRIPTION
## Summary
- Replaced card-based wallet entry layout with a compact `MudTable` for row-input format
- Compacted selection mode from two large cards to an inline button row with status chips
- Denomination entry now uses expandable child rows (`ChildRowContent`) instead of `MudExpansionPanel`
- Totals displayed in table footer; action buttons below table

Closes #36

## Test plan
- [ ] Navigate to `/cashcount` and verify the selection mode shows compact button row
- [ ] Start an opening count and verify wallets render as table rows with inline inputs
- [ ] For denomination wallets, expand/collapse the detail row and enter denominations
- [ ] Verify counted amount auto-updates from denomination totals
- [ ] Start a closing count and verify Expected and Variance columns appear
- [ ] Test Save Draft and Submit still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)