### PR TITLE
fix: reset password dialog close button not working

### DIFF
--- a/EastSeat.Agenti.Web/Components/Pages/UserDetail.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/UserDetail.razor
@@ -78,9 +78,7 @@ else
     </MudPaper>
 }
 
-@if (showPasswordDialog && !string.IsNullOrEmpty(newPassword))
-{
-    <MudDialog @bind-Visible="showPasswordDialog" Options="new DialogOptions() { MaxWidth = MaxWidth.Small, FullWidth = true }">
+<MudDialog @bind-Visible="showPasswordDialog" Options="new DialogOptions() { MaxWidth = MaxWidth.Small, FullWidth = true }">
         <TitleContent>
             <MudText Typo="Typo.h6">Password Reset Successful</MudText>
         </TitleContent>
@@ -112,8 +110,7 @@ else
         <DialogActions>
             <MudButton OnClick="ClosePasswordDialog" Color="Color.Primary" Variant="Variant.Filled">Close</MudButton>
         </DialogActions>
-    </MudDialog>
-}
+</MudDialog>
 
 @code {
     [Parameter] public string Id { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- Fixes the reset password dialog not closing when the Close button is clicked (#31)
- Removed the `@if` wrapper around the `<MudDialog>` that was competing with `@bind-Visible`, preventing MudBlazor from completing its close lifecycle
- Dialog visibility is now controlled solely by `@bind-Visible="showPasswordDialog"`, matching the working pattern in `AgentDetail.razor`

## Test plan
- [ ] Navigate to a user detail page and click Reset Password
- [ ] Verify the dialog opens showing the new password
- [ ] Click Close — dialog should dismiss cleanly
- [ ] Verify no overlay/backdrop remains after closing

🤖 Generated with [Claude Code](https://claude.com/claude-code)