### PR TITLE
fix: reset login button state after failed login attempt

### DIFF
--- a/EastSeat.Agenti.Web/Components/Account/Pages/Login.razor
+++ b/EastSeat.Agenti.Web/Components/Account/Pages/Login.razor
@@ -214,6 +214,8 @@
             Logger.LogWarning("Invalid login attempt for email: {Email}", Input.Email);
             errorMessage = "Error: Invalid login attempt.";
         }
+
+        _isLoggingIn = false;
     }
 
     private sealed class InputModel


### PR DESCRIPTION
## Summary
- Fix login button becoming permanently disabled after a failed login attempt
- The `_isLoggingIn` flag was set to `true` at the start of `LoginUser()` but never reset to `false` when login failed, leaving the Sign In button disabled

## Root Cause
In `Login.razor`, the `_isLoggingIn` boolean controls the button's `Disabled` state. On successful login or redirect paths (2FA, lockout), the page navigates away so the flag doesn't matter. But on the "invalid credentials" and "not allowed" error paths, the page stays rendered with `_isLoggingIn = true`, permanently disabling the button.

## Fix
Added `_isLoggingIn = false;` at the end of `LoginUser()` so the button is re-enabled after any non-redirect outcome.

Closes #49

## Test plan
- [ ] Enter invalid credentials → verify error message appears and Sign In button is re-enabled
- [ ] Enter valid credentials → verify login succeeds as before
- [ ] Verify all unit tests pass (`dotnet test tests/EastSeat.Agenti.UnitTests` — 246 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)