### PR TITLE
feat: add health check endpoints for Azure App Service

### DIFF
--- a/EastSeat.Agenti.Web/EastSeat.Agenti.Web.csproj
+++ b/EastSeat.Agenti.Web/EastSeat.Agenti.Web.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.1" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />

--- a/EastSeat.Agenti.Web/Program.cs
+++ b/EastSeat.Agenti.Web/Program.cs
@@ -25,6 +25,8 @@ using MudBlazor.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,6 +36,7 @@ var serilogConfig = new LoggerConfiguration()
     .MinimumLevel.Information()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
     .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Information)
+    .MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.HealthChecks", LogEventLevel.Warning)
     .Enrich.FromLogContext()
     .Enrich.WithProperty("Application", "Agenti")
     .WriteTo.Console();
@@ -173,6 +176,12 @@ builder.Services.AddAuthorizationBuilder()
         policy.RequireRole(UserRole.Admin.ToString())
               .AddAuthenticationSchemes(IdentityConstants.ApplicationScheme, JwtBearerDefaults.AuthenticationScheme));
 
+// Add health checks
+builder.Services.AddHealthChecks()
+    .AddDbContextCheck<ApplicationDbContext>(
+        name: "postgresql",
+        tags: ["db", "ready"]);
+
 // Add REST API support
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
@@ -305,6 +314,23 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
+// Health check endpoints
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    Predicate = _ => true,
+    ResponseWriter = WriteHealthCheckResponse
+}).AllowAnonymous();
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = _ => false
+}).AllowAnonymous();
+
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready")
+}).AllowAnonymous();
+
 // Map REST API endpoints (for Android app)
 var apiGroup = app.MapGroup("/api");
 
@@ -355,6 +381,7 @@ app.Use(async (context, next) =>
                        path.StartsWith("/lib", StringComparison.OrdinalIgnoreCase) ||
                        path.StartsWith("/favicon", StringComparison.OrdinalIgnoreCase);
     var isApiPath = path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase);
+    var isHealthCheck = path.StartsWith("/health", StringComparison.OrdinalIgnoreCase);
 
     if (!setupCompleteFlag)
     {
@@ -363,7 +390,7 @@ app.Use(async (context, next) =>
         setupCompleteFlag = await setupService.IsSetupCompleteAsync();
     }
 
-    if (!setupCompleteFlag && !isSetupPage && !isStaticAsset && !isApiPath)
+    if (!setupCompleteFlag && !isSetupPage && !isStaticAsset && !isApiPath && !isHealthCheck)
     {
         var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
         logger.LogInformation("Setup incomplete. Redirecting to setup page from {Path}", path);
@@ -399,4 +426,25 @@ catch (Exception ex)
 finally
 {
     Log.CloseAndFlush();
+}
+
+static async Task WriteHealthCheckResponse(HttpContext context, HealthReport report)
+{
+    context.Response.ContentType = "application/json";
+
+    var result = new
+    {
+        status = report.Status.ToString(),
+        totalDuration = report.TotalDuration.TotalMilliseconds,
+        checks = report.Entries.Select(e => new
+        {
+            name = e.Key,
+            status = e.Value.Status.ToString(),
+            duration = e.Value.Duration.TotalMilliseconds,
+            description = e.Value.Description,
+            exception = e.Value.Exception?.Message
+        })
+    };
+
+    await context.Response.WriteAsJsonAsync(result);
 }


### PR DESCRIPTION
## Summary
- Add ASP.NET Core health check middleware with PostgreSQL connectivity check via EF Core `AddDbContextCheck`
- Map three anonymous endpoints: `/health` (full), `/health/live` (liveness), `/health/ready` (readiness)
- Exclude `/health` from setup redirect middleware so probes work during initial setup
- Suppress health check request log noise via Serilog level override

## Azure App Service Configuration
After merging, enable health checks on the App Service:
```bash
az webapp config set --resource-group <rg> --name <app> \
    --generic-configurations '{"healthCheckPath": "/health"}'
```
Or via Portal: **Monitoring > Health check** → Enable → Path: `/health`

## Test plan
- [ ] Verify `dotnet build` succeeds
- [ ] Verify unit tests pass (`dotnet test tests/EastSeat.Agenti.UnitTests`)
- [ ] Run locally and confirm `/health` returns JSON with `Healthy` status
- [ ] Confirm `/health/live` returns 200 with no checks
- [ ] Confirm `/health/ready` returns PostgreSQL check result
- [ ] Verify health endpoints work before setup is complete (no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)