### PR TITLE
fix: add missing app.js script to fix logout failure

### DIFF
--- a/EastSeat.Agenti.Web/Components/App.razor
+++ b/EastSeat.Agenti.Web/Components/App.razor
@@ -18,6 +18,7 @@
 
 <body>
     <Routes @rendermode="@PageRenderMode" />
+    <script src="app.js"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- **Bug:** Clicking logout threw `JSInterop.JSException: The value 'submitForm' is not a function` because `app.js` was never loaded in `App.razor`.
- **Fix:** Added `<script src="app.js"></script>` to `App.razor` before the Blazor framework script.
- This also restores `copyToClipboard` and `themeHelpers` JS functions which were broken for the same reason.

## Test plan
- [ ] Deploy to Azure and verify clicking the logout menu item signs the user out and redirects to `/`
- [ ] Verify no `JSInterop` exceptions in Application Insights after logout
- [ ] Verify theme detection and clipboard copy still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)