### PR TITLE
feat: vault surplus visibility and audit trail

### DIFF
--- a/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
@@ -273,8 +273,8 @@
                     @if (!_countForm.IsOpening)
                     {
                         <MudTh Style="text-align: right;">
-                            <MudText Color="@(_countForm.TotalVariance == 0 ? Color.Success : Color.Warning)">
-                                <strong>@_countForm.TotalVariance.ToString("N0")</strong>
+                            <MudText Color="@(_countForm.TotalVariance == 0 ? Color.Success : (_countForm.TotalVariance > 0 ? Color.Info : Color.Warning))">
+                                <strong>@(_countForm.TotalVariance > 0 ? "+" : "")@_countForm.TotalVariance.ToString("N0")</strong>
                             </MudText>
                         </MudTh>
                     }
@@ -285,7 +285,8 @@
             <!-- Explanation field for closing counts with discrepancy -->
             @if (!_countForm.IsOpening && _countForm.TotalVariance != 0)
             {
-                <MudTextField @bind-Value="_countForm.Explanation" Label="Explanation for discrepancy"
+                <MudTextField @bind-Value="_countForm.Explanation"
+                    Label="@(_countForm.TotalVariance > 0 ? "Explanation for surplus" : "Explanation for shortage")"
                     Variant="Variant.Outlined" Lines="3" Class="mt-3"
                     HelperText="Required: explain the difference between opening and closing amounts"
                     Required="true" RequiredError="Explanation is required when there is a discrepancy" />

--- a/EastSeat.Agenti.Web/Components/Pages/CashCountApprovals.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/CashCountApprovals.razor
@@ -74,8 +74,8 @@
                 <MudTd DataLabel="Variance" Style="text-align: right;">
                     @if (context.HasDiscrepancy && context.Variance.HasValue)
                     {
-                        <MudText Typo="Typo.body2" Color="Color.Warning">
-                            @context.Variance.Value.ToString("N0")
+                        <MudText Typo="Typo.body2" Color="@(context.Variance.Value > 0 ? Color.Info : Color.Warning)">
+                            @(context.Variance.Value > 0 ? "+" : "")@context.Variance.Value.ToString("N0")
                         </MudText>
                     }
                     else if (!context.IsOpening && context.OpeningTotal.HasValue)
@@ -107,8 +107,9 @@
 
         @foreach (var item in _pending.Where(p => !string.IsNullOrEmpty(p.Explanation)))
         {
-            <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Class="mt-2" Dense="true">
-                <strong>@item.AgentName (@(item.IsOpening ? "Opening" : "Closing")):</strong> @item.Explanation
+            var isSurplus = item.Variance.HasValue && item.Variance.Value > 0;
+            <MudAlert Severity="@(isSurplus ? Severity.Info : Severity.Warning)" Variant="Variant.Text" Class="mt-2" Dense="true">
+                <strong>@item.AgentName (@(item.IsOpening ? "Opening" : "Closing") — @(isSurplus ? "Surplus" : "Shortage") @(item.Variance.HasValue ? $"UGX {Math.Abs(item.Variance.Value):N0}" : "")):</strong> @item.Explanation
             </MudAlert>
         }
     }

--- a/EastSeat.Agenti.Web/Components/Pages/CashSessionDetail.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/CashSessionDetail.razor
@@ -111,7 +111,14 @@
                             <MudText Typo="Typo.caption" Color="Color.Secondary">(@agent.AgentCode)</MudText>
                             @if (agent.HasDiscrepancy)
                             {
-                                <MudChip T="string" Size="Size.Small" Color="Color.Warning">Discrepancy</MudChip>
+                                @if (agent.Variance.HasValue && agent.Variance.Value > 0)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Info">Surplus</MudChip>
+                                }
+                                else
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Warning">Shortage</MudChip>
+                                }
                             }
                         </MudStack>
                     </CardHeaderContent>
@@ -180,8 +187,8 @@
                                 <MudText Typo="Typo.body1" Class="mt-1">UGX @agent.ClosingCount.TotalAmount.ToString("N0")</MudText>
                                 @if (agent.Variance.HasValue && agent.Variance.Value != 0)
                                 {
-                                    <MudText Typo="Typo.body2" Color="Color.Warning" Class="mt-1">
-                                        Variance: UGX @agent.Variance.Value.ToString("N0")
+                                    <MudText Typo="Typo.body2" Color="@(agent.Variance.Value > 0 ? Color.Info : Color.Warning)" Class="mt-1">
+                                        @(agent.Variance.Value > 0 ? "Surplus" : "Shortage"): UGX @(agent.Variance.Value > 0 ? "+" : "")@agent.Variance.Value.ToString("N0")
                                     </MudText>
                                 }
                                 @if (!string.IsNullOrEmpty(agent.ClosingCount.Explanation))

--- a/EastSeat.Agenti.Web/Components/Pages/Vault.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/Vault.razor
@@ -85,8 +85,8 @@
                                     </MudTd>
                                     <MudTd DataLabel="Amount">
                                         <MudText
-                                            Color="@(trx.Type == VaultTransactionType.ManualDeposit ? Color.Success : Color.Error)">
-                                            @(trx.Type == VaultTransactionType.ManualDeposit ? "+" :
+                                            Color="@(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.SurplusDeposit ? Color.Success : Color.Error)">
+                                            @(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.SurplusDeposit ? "+" :
                                                                                 "-")UGX @trx.Amount.ToString("N0")
                                         </MudText>
                                     </MudTd>
@@ -169,8 +169,8 @@
                             </MudTd>
                             <MudTd DataLabel="Amount">
                                 <MudText
-                                    Color="@(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.Closing ? Color.Success : Color.Error)">
-                                    @(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.Closing
+                                    Color="@(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.Closing || trx.Type == VaultTransactionType.SurplusDeposit ? Color.Success : Color.Error)">
+                                    @(trx.Type == VaultTransactionType.ManualDeposit || trx.Type == VaultTransactionType.Closing || trx.Type == VaultTransactionType.SurplusDeposit
                                                                 ? "+" : "-")UGX @trx.Amount.ToString("N0")
                                 </MudText>
                             </MudTd>
@@ -325,6 +325,7 @@
         VaultTransactionType.Closing => Color.Info,
         VaultTransactionType.ManualDeposit => Color.Success,
         VaultTransactionType.ManualWithdrawal => Color.Error,
+        VaultTransactionType.SurplusDeposit => Color.Success,
         _ => Color.Default
     };
 
@@ -334,6 +335,7 @@
         VaultTransactionType.Closing => Icons.Material.Filled.Output,
         VaultTransactionType.ManualDeposit => Icons.Material.Filled.AddCircle,
         VaultTransactionType.ManualWithdrawal => Icons.Material.Filled.RemoveCircle,
+        VaultTransactionType.SurplusDeposit => Icons.Material.Filled.TrendingUp,
         _ => Icons.Material.Filled.Help
     };
 
@@ -343,6 +345,7 @@
         VaultTransactionType.Closing => "Closing",
         VaultTransactionType.ManualDeposit => "Deposit",
         VaultTransactionType.ManualWithdrawal => "Withdrawal",
+        VaultTransactionType.SurplusDeposit => "Surplus",
         _ => "Unknown"
     };
 

--- a/EastSeat.Agenti.Web/Components/Pages/Vault.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/Vault.razor
@@ -325,7 +325,7 @@
         VaultTransactionType.Closing => Color.Info,
         VaultTransactionType.ManualDeposit => Color.Success,
         VaultTransactionType.ManualWithdrawal => Color.Error,
-        VaultTransactionType.SurplusDeposit => Color.Success,
+        VaultTransactionType.SurplusDeposit => Color.Info,
         _ => Color.Default
     };
 

--- a/EastSeat.Agenti.Web/Features/CashCounts/CashCountService.cs
+++ b/EastSeat.Agenti.Web/Features/CashCounts/CashCountService.cs
@@ -937,7 +937,7 @@ public class CashCountService(
                             Amount = discrepancy.Variance,
                             Type = VaultTransactionType.SurplusDeposit,
                             Status = VaultTransactionStatus.Completed,
-                            BalanceAfter = null,
+                            BalanceAfter = vault.CurrentBalance,
                             CreatedAt = DateTimeOffset.UtcNow,
                             CreatedByUserId = userId,
                             Notes = $"Surplus of UGX {discrepancy.Variance:N0} on closing count (expected {discrepancy.ExpectedAmount:N0}, actual {discrepancy.ActualAmount:N0})"

--- a/EastSeat.Agenti.Web/Features/CashCounts/CashCountService.cs
+++ b/EastSeat.Agenti.Web/Features/CashCounts/CashCountService.cs
@@ -923,6 +923,27 @@ public class CashCountService(
                 discrepancy.ApprovedByUserId = isAutoApproval ? null : userId;
                 discrepancy.ApprovedAt = DateTimeOffset.UtcNow;
                 discrepancy.ApprovalNotes = isAutoApproval ? "Auto-approved (closing matches opening)" : null;
+
+                // Create audit-only vault transaction for surplus (closing > opening)
+                if (discrepancy.Variance > 0)
+                {
+                    var vault = await dbContext.Vaults.FirstOrDefaultAsync(v => v.BranchId == branchId);
+                    if (vault != null)
+                    {
+                        dbContext.VaultTransactions.Add(new VaultTransaction
+                        {
+                            VaultId = vault.Id,
+                            CashSessionId = cashCount.CashSessionId,
+                            Amount = discrepancy.Variance,
+                            Type = VaultTransactionType.SurplusDeposit,
+                            Status = VaultTransactionStatus.Completed,
+                            BalanceAfter = null,
+                            CreatedAt = DateTimeOffset.UtcNow,
+                            CreatedByUserId = userId,
+                            Notes = $"Surplus of UGX {discrepancy.Variance:N0} on closing count (expected {discrepancy.ExpectedAmount:N0}, actual {discrepancy.ActualAmount:N0})"
+                        });
+                    }
+                }
             }
 
             await dbContext.SaveChangesAsync();

--- a/EastSeat.Agenti.Web/Shared/Domain/Enums/VaultTransactionType.cs
+++ b/EastSeat.Agenti.Web/Shared/Domain/Enums/VaultTransactionType.cs
@@ -9,5 +9,6 @@ public enum VaultTransactionType
     Closing = 2,
     ManualDeposit = 3,
     ManualWithdrawal = 4,
-    Adjustment = 5
+    Adjustment = 5,
+    SurplusDeposit = 6
 }

--- a/tests/EastSeat.Agenti.UnitTests/Services/CashCountServiceTests.cs
+++ b/tests/EastSeat.Agenti.UnitTests/Services/CashCountServiceTests.cs
@@ -795,4 +795,223 @@ public class CashCountServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Surplus Scenarios
+
+    [Fact]
+    public async Task SubmitCashCountAsync_ClosingWithSurplus_CreatesDiscrepancyWithPositiveVariance()
+    {
+        var session = CashSessionBuilder.Default()
+            .WithBranchId(_testBranch.Id)
+            .AsOpen()
+            .Build();
+        _dbContext.CashSessions.Add(session);
+        await _dbContext.SaveChangesAsync();
+
+        var openingCount = CashCountBuilder.Default()
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsOpening()
+            .AsApproved()
+            .WithTotalAmount(1000m)
+            .Build();
+        _dbContext.CashCounts.Add(openingCount);
+        await _dbContext.SaveChangesAsync();
+
+        var closingCount = CashCountBuilder.Default()
+            .WithId(2)
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsClosing()
+            .WithStatus(CashCountStatus.Draft)
+            .WithTotalAmount(1200m) // Surplus: 200 more than opening
+            .WithExplanation("Customer returned excess change")
+            .Build();
+        _dbContext.CashCounts.Add(closingCount);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _sut.SubmitCashCountAsync(_testUser.Id, closingCount.Id);
+
+        result.Success.Should().BeTrue();
+
+        var discrepancy = await _dbContext.Discrepancies
+            .FirstOrDefaultAsync(d => d.CashCountId == closingCount.Id);
+        discrepancy.Should().NotBeNull();
+        discrepancy!.Variance.Should().Be(200m);
+        discrepancy.ExpectedAmount.Should().Be(1000m);
+        discrepancy.ActualAmount.Should().Be(1200m);
+        discrepancy.Status.Should().Be(DiscrepancyStatus.PendingReview);
+    }
+
+    [Fact]
+    public async Task SubmitCashCountAsync_ClosingWithSurplus_RequiresExplanation()
+    {
+        var session = CashSessionBuilder.Default()
+            .WithBranchId(_testBranch.Id)
+            .AsOpen()
+            .Build();
+        _dbContext.CashSessions.Add(session);
+        await _dbContext.SaveChangesAsync();
+
+        var openingCount = CashCountBuilder.Default()
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsOpening()
+            .AsApproved()
+            .WithTotalAmount(1000m)
+            .Build();
+        _dbContext.CashCounts.Add(openingCount);
+        await _dbContext.SaveChangesAsync();
+
+        var closingCount = CashCountBuilder.Default()
+            .WithId(2)
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsClosing()
+            .WithStatus(CashCountStatus.Draft)
+            .WithTotalAmount(1200m) // Surplus without explanation
+            .Build();
+        _dbContext.CashCounts.Add(closingCount);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _sut.SubmitCashCountAsync(_testUser.Id, closingCount.Id);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("explanation");
+    }
+
+    [Fact]
+    public async Task ApproveCashCountAsync_ClosingWithSurplus_CreatesSurplusVaultTransaction()
+    {
+        var adminUser = UserBuilder.Default()
+            .WithEmail("admin@test.com")
+            .WithRole(UserRole.Admin)
+            .Build();
+        _dbContext.Users.Add(adminUser);
+        await _dbContext.SaveChangesAsync();
+
+        // Use the auto-created vault (created when _testBranch was added)
+        var vault = await _dbContext.Vaults.FirstAsync(v => v.BranchId == _testBranch.Id);
+
+        var session = CashSessionBuilder.Default()
+            .WithBranchId(_testBranch.Id)
+            .AsOpen()
+            .Build();
+        _dbContext.CashSessions.Add(session);
+        await _dbContext.SaveChangesAsync();
+
+        var closingCount = CashCountBuilder.Default()
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsClosing()
+            .AsSubmitted()
+            .WithTotalAmount(1200m)
+            .Build();
+        _dbContext.CashCounts.Add(closingCount);
+
+        var detail = CashCountDetailBuilder.Default()
+            .WithCashCountId(closingCount.Id)
+            .WithWalletId(_testWallet.Id)
+            .WithAmount(1200m)
+            .Build();
+        _dbContext.CashCountDetails.Add(detail);
+
+        // Create a pending discrepancy with positive variance (surplus)
+        var discrepancy = new Discrepancy
+        {
+            CashSessionId = session.Id,
+            CashCountId = closingCount.Id,
+            Status = DiscrepancyStatus.PendingReview,
+            ExpectedAmount = 1000m,
+            ActualAmount = 1200m,
+            Variance = 200m,
+            Explanation = "Customer returned excess change",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.Discrepancies.Add(discrepancy);
+        await _dbContext.SaveChangesAsync();
+
+        _vaultServiceMock
+            .Setup(x => x.DepositForSessionAsync(
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<decimal>(),
+                It.IsAny<string>(), false, default))
+            .ReturnsAsync(VaultOperationResult.Ok(1));
+
+        var result = await _sut.ApproveCashCountAsync(adminUser.Id, closingCount.Id);
+
+        result.Success.Should().BeTrue();
+
+        var surplusTransaction = await _dbContext.VaultTransactions
+            .FirstOrDefaultAsync(vt => vt.Type == VaultTransactionType.SurplusDeposit);
+        surplusTransaction.Should().NotBeNull();
+        surplusTransaction!.Amount.Should().Be(200m);
+        surplusTransaction.VaultId.Should().Be(vault.Id);
+        surplusTransaction.Status.Should().Be(VaultTransactionStatus.Completed);
+        surplusTransaction.Notes.Should().Contain("Surplus");
+    }
+
+    [Fact]
+    public async Task ApproveCashCountAsync_ClosingWithShortage_DoesNotCreateSurplusTransaction()
+    {
+        var adminUser = UserBuilder.Default()
+            .WithEmail("admin@test.com")
+            .WithRole(UserRole.Admin)
+            .Build();
+        _dbContext.Users.Add(adminUser);
+        await _dbContext.SaveChangesAsync();
+
+        var session = CashSessionBuilder.Default()
+            .WithBranchId(_testBranch.Id)
+            .AsOpen()
+            .Build();
+        _dbContext.CashSessions.Add(session);
+        await _dbContext.SaveChangesAsync();
+
+        var closingCount = CashCountBuilder.Default()
+            .WithCashSessionId(session.Id)
+            .WithAgentId(_testAgent.Id)
+            .AsClosing()
+            .AsSubmitted()
+            .WithTotalAmount(800m)
+            .Build();
+        _dbContext.CashCounts.Add(closingCount);
+
+        var detail = CashCountDetailBuilder.Default()
+            .WithCashCountId(closingCount.Id)
+            .WithWalletId(_testWallet.Id)
+            .WithAmount(800m)
+            .Build();
+        _dbContext.CashCountDetails.Add(detail);
+
+        // Create a pending discrepancy with negative variance (shortage)
+        var discrepancy = new Discrepancy
+        {
+            CashSessionId = session.Id,
+            CashCountId = closingCount.Id,
+            Status = DiscrepancyStatus.PendingReview,
+            ExpectedAmount = 1000m,
+            ActualAmount = 800m,
+            Variance = -200m,
+            Explanation = "Cash was lost during the day",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.Discrepancies.Add(discrepancy);
+        await _dbContext.SaveChangesAsync();
+
+        _vaultServiceMock
+            .Setup(x => x.DepositForSessionAsync(
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<decimal>(),
+                It.IsAny<string>(), false, default))
+            .ReturnsAsync(VaultOperationResult.Ok(1));
+
+        var result = await _sut.ApproveCashCountAsync(adminUser.Id, closingCount.Id);
+
+        result.Success.Should().BeTrue();
+
+        var surplusTransaction = await _dbContext.VaultTransactions
+            .FirstOrDefaultAsync(vt => vt.Type == VaultTransactionType.SurplusDeposit);
+        surplusTransaction.Should().BeNull();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Distinguish **surplus** (closing > opening) from **shortage** across all cash count UI pages with color-coded labels (`Color.Info` for surplus, `Color.Warning` for shortage)
- Create an audit-only `SurplusDeposit` vault transaction when a surplus closing count is approved, recording the surplus amount separately for audit visibility
- Add `SurplusDeposit = 6` to `VaultTransactionType` enum (no migration needed — stored as string)
- Add 4 unit tests covering surplus submission, explanation requirement, surplus audit transaction creation, and shortage non-creation

Closes #63

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 284 tests passed (261 passed, 23 pre-existing skips, 0 failures)
- [ ] Manual: submit closing count with surplus → verify "Explanation for surplus" label and `Color.Info` variance
- [ ] Manual: approve surplus closing → verify `SurplusDeposit` transaction appears in vault history with TrendingUp icon
- [ ] Manual: verify approval page shows "Surplus UGX X" label with blue color for surplus items
- [ ] Manual: verify session detail shows "Surplus" chip instead of generic "Discrepancy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)