### PR TITLE
fix: compute closing cash count variance on total, not individual wallets

### DIFF
--- a/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
+++ b/EastSeat.Agenti.Web/Components/Pages/CashCount.razor
@@ -196,10 +196,6 @@
                         <MudTh Style="text-align: right;">Expected (UGX)</MudTh>
                     }
                     <MudTh Style="text-align: right;">Counted (UGX)</MudTh>
-                    @if (!_countForm.IsOpening)
-                    {
-                        <MudTh Style="text-align: right;">Variance</MudTh>
-                    }
                     <MudTh Style="width: 50px;"></MudTh>
                 </HeaderContent>
                 <RowTemplate>
@@ -225,15 +221,6 @@
                                 Style="max-width: 160px; display: inline-flex;" HideSpinButtons="true" />
                         }
                     </MudTd>
-                    @if (!_countForm.IsOpening)
-                    {
-                        <MudTd DataLabel="Variance" Style="text-align: right;">
-                            <MudText Typo="Typo.body2"
-                                Color="@(context.Variance == 0 ? Color.Default : (context.Variance > 0 ? Color.Info : Color.Warning))">
-                                @context.Variance.ToString("N0")
-                            </MudText>
-                        </MudTd>
-                    }
                     <MudTd Style="text-align: center;">
                         @if (context.SupportsDenominations)
                         {
@@ -326,17 +313,22 @@
                     <MudTh Style="text-align: right;">
                         <strong>@_countForm.TotalAmount.ToString("N0")</strong>
                     </MudTh>
-                    @if (!_countForm.IsOpening)
-                    {
-                        <MudTh Style="text-align: right;">
-                            <MudText Color="@(_countForm.TotalVariance == 0 ? Color.Success : (_countForm.TotalVariance > 0 ? Color.Info : Color.Warning))">
-                                <strong>@(_countForm.TotalVariance > 0 ? "+" : "")@_countForm.TotalVariance.ToString("N0")</strong>
-                            </MudText>
-                        </MudTh>
-                    }
                     <MudTh></MudTh>
                 </FooterContent>
             </MudTable>
+
+            @if (!_countForm.IsOpening)
+            {
+                <MudPaper Class="pa-3 mt-2" Elevation="1">
+                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                        <MudText Typo="Typo.subtitle1">Total Variance</MudText>
+                        <MudText Typo="Typo.h6"
+                            Color="@(_countForm.TotalVariance == 0 ? Color.Success : (_countForm.TotalVariance > 0 ? Color.Info : Color.Warning))">
+                            @(_countForm.TotalVariance > 0 ? "+" : "")@_countForm.TotalVariance.ToString("N0") UGX
+                        </MudText>
+                    </MudStack>
+                </MudPaper>
+            }
 
             <!-- Explanation field for closing counts with discrepancy -->
             @if (!_countForm.IsOpening && _countForm.TotalVariance != 0)

--- a/EastSeat.Agenti.Web/Features/CashCounts/CashCountDtos.cs
+++ b/EastSeat.Agenti.Web/Features/CashCounts/CashCountDtos.cs
@@ -14,9 +14,6 @@ public class WalletCountEntryDto
     public decimal ExpectedBalance { get; set; }
     public decimal CountedAmount { get; set; }
     public DenominationBreakdown? Denominations { get; set; }
-
-    public decimal Variance => CountedAmount - ExpectedBalance;
-    public bool HasDiscrepancy => Variance != 0;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Remove per-wallet variance column from closing cash count table — individual wallet variances were misleading since only the total variance matters for discrepancy detection
- Display total variance prominently below the table in a standalone summary element
- Remove unused `Variance` and `HasDiscrepancy` computed properties from `WalletCountEntryDto`
- No service-layer changes needed — the service already correctly computes variance at the total level

Closes #69

## Test plan
- [x] `dotnet build` — no compilation errors
- [x] `dotnet test` — all 283 unit tests pass (0 failures)
- [ ] Manual: verify closing count table shows Wallet, Type, Expected, Counted columns (no Variance column)
- [ ] Manual: verify total variance appears below the table with correct color coding
- [ ] Manual: verify explanation field still triggers when total variance != 0
- [ ] Manual: verify opening count form is unchanged
- [ ] Manual: verify CashCountApprovals page still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)